### PR TITLE
Updated Selenium.WebDriver and removed the deprecated PhantomJS package

### DIFF
--- a/examples/Protractor.Samples/Basic/BasicTests.cs
+++ b/examples/Protractor.Samples/Basic/BasicTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
 using OpenQA.Selenium;
-using OpenQA.Selenium.PhantomJS;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.IE;
 using OpenQA.Selenium.Edge;

--- a/examples/Protractor.Samples/MockHttpBackend/MockHttpBackendTests.cs
+++ b/examples/Protractor.Samples/MockHttpBackend/MockHttpBackendTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
 using OpenQA.Selenium;
-using OpenQA.Selenium.PhantomJS;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.IE;
 using OpenQA.Selenium.Edge;

--- a/examples/Protractor.Samples/PageObjects/PageObjectsTests.cs
+++ b/examples/Protractor.Samples/PageObjects/PageObjectsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
 using OpenQA.Selenium;
-using OpenQA.Selenium.PhantomJS;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.IE;
 using OpenQA.Selenium.Edge;

--- a/examples/Protractor.Samples/Protractor.Samples-NET.csproj
+++ b/examples/Protractor.Samples/Protractor.Samples-NET.csproj
@@ -18,10 +18,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="PhantomJS" Version="2.1.1" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.20.0" />
-    <PackageReference Include="Selenium.Support" Version="3.6.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.6.0" />
+    <PackageReference Include="Selenium.Support" Version="3.14.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="2.38.0" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="3.11.1" />
     <PackageReference Include="Selenium.WebDriver.MicrosoftWebDriver" Version="10.0.16299" />

--- a/src/Protractor/NgWebDriver.cs
+++ b/src/Protractor/NgWebDriver.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 
 using OpenQA.Selenium;
 using OpenQA.Selenium.Internal;
+using OpenQA.Selenium.Remote;
 
 namespace Protractor
 {
@@ -141,11 +142,12 @@ namespace Protractor
                 // TODO: test Android
                 IHasCapabilities hcDriver = this.driver as IHasCapabilities;
                 if (hcDriver != null &&
-                    (hcDriver.Capabilities.BrowserName == "internet explorer" ||
-                     hcDriver.Capabilities.BrowserName == "MicrosoftEdge" ||
-                     hcDriver.Capabilities.BrowserName == "phantomjs" ||
-                     hcDriver.Capabilities.BrowserName == "firefox" ||
-                     hcDriver.Capabilities.BrowserName.ToLower() == "safari"))
+                    hcDriver.Capabilities.HasCapability(CapabilityType.BrowserName) &&
+                    (hcDriver.Capabilities[CapabilityType.BrowserName].ToString() == "internet explorer" ||
+                     hcDriver.Capabilities[CapabilityType.BrowserName].ToString() == "MicrosoftEdge" ||
+                     hcDriver.Capabilities[CapabilityType.BrowserName].ToString() == "phantomjs" ||
+                     hcDriver.Capabilities[CapabilityType.BrowserName].ToString() == "firefox" ||
+                     hcDriver.Capabilities[CapabilityType.BrowserName].ToString().ToLower() == "safari"))
                 {
                     this.ExecuteScript("window.name += '" + AngularDeferBootstrap + "';");
                     this.driver.Url = value;

--- a/src/Protractor/Protractor-NET.csproj
+++ b/src/Protractor/Protractor-NET.csproj
@@ -26,6 +26,6 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Selenium.WebDriver" Version="3.11.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Selenium introduced a breaking change in the `ICapabilities` interface in version 3.14.
PhantomJS has been removed, as it's no longer being maintained and also removed from Selenium.